### PR TITLE
fix format of the license (sic!)

### DIFF
--- a/build/pkgs/meson_python/patches/formatlicense.patch
+++ b/build/pkgs/meson_python/patches/formatlicense.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 70818ab..4aa9680 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -19,7 +19,7 @@ version = '0.18.0'
+ description = 'Meson Python build backend (PEP 517)'
+ readme = 'README.rst'
+ requires-python = '>= 3.8'
+-license = 'MIT'
++license = {text = 'MIT'}
+ license-files = ['LICENSES/MIT.txt']
+ keywords = ['meson', 'build', 'backend', 'pep517', 'package']
+ maintainers = [

--- a/build/pkgs/meson_python/spkg-install.in
+++ b/build/pkgs/meson_python/spkg-install.in
@@ -1,2 +1,2 @@
 cd src
-sdh_pip_install --no-build-isolation --no-deps .
+sdh_pip_install .


### PR DESCRIPTION
without the patch, we get

[meson_python-0.18.0] [spkg-install] meson-python: error: Field "project.license" has an invalid type, expecting a dictionary of strings (got "MIT")

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


